### PR TITLE
Fix Gaussian Noise on PulseGenerator

### DIFF
--- a/reconstruction/CaloRecBuilder/src/PulseGenerator.cxx
+++ b/reconstruction/CaloRecBuilder/src/PulseGenerator.cxx
@@ -113,7 +113,7 @@ void PulseGenerator::ReadShaper( std::string filepath )
 void PulseGenerator::AddGaussianNoise( std::vector<float> &pulse, float noiseMean, float noiseStd) const
 {
   for ( auto &value : pulse )
-    value+= m_pedestal + m_rng.Gaus( noiseMean, noiseStd );
+    value += m_rng.Gaus( noiseMean, noiseStd );
 }
 
 


### PR DESCRIPTION
The value of the pedestal was being added improperly during the addition of Gaussian noise. Note that the pedestal value is already being added at https://github.com/jodafons/lorenzetti/blob/72f8ad42f7cb5d10ccc56bb2e190dbcd7fb88a74/reconstruction/CaloRecBuilder/src/PulseGenerator.cxx#L134